### PR TITLE
* WP 5.7 Gutenberg widgets screen has JS error which breaks page savi…

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,3 +1,7 @@
+= 1.0.24 =
+* WP 5.7 Gutenberg widgets screen has JS error which breaks page saving - FIXED
+* WP 5.7 Gutenberg widgets screen legacy widgets have no `show advanced` button - FIXED
+
 = 1.0.23 =
 * Rows argument now available to group arguments to the one row - ADDED
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ayecode/wp-super-duper",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "type": "library",
   "description": "Lets you create a widget, block and shortcode all from the one file .",
   "keywords": ["WordPress","super duper","wp"],

--- a/wp-super-duper.php
+++ b/wp-super-duper.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WP_Super_Duper' ) ) {
 	 */
 	class WP_Super_Duper extends WP_Widget {
 
-		public $version = "1.0.23";
+		public $version = "1.0.24";
 		public $font_awesome_icon_version = "5.11.2";
 		public $block_code;
 		public $options;
@@ -1140,8 +1140,11 @@ if ( ! class_exists( 'WP_Super_Duper' ) ) {
 
 					if (jQuery($this).val() == '1' && jQuery(form).find('.sd-advanced-button').length == 0) {
 						console.log('add advanced button');
-
-						jQuery(form).find('.widget-control-save').after($button);
+						if(jQuery(form).find('.widget-control-save').length > 0){
+							jQuery(form).find('.widget-control-save').after($button);
+						}else{
+							jQuery(form).find('.sd-show-advanced').after($button);
+						}
 					} else {
 						console.log('no advanced button');
 						console.log(jQuery($this).val());
@@ -1854,7 +1857,7 @@ if ( ! class_exists( 'WP_Super_Duper' ) ) {
 										'attributes': props.attributes,
 										'post_id': <?php global $post; if ( isset( $post->ID ) ) {
 										echo $post->ID;
-									}?>,
+									}else{echo '0';}?>,
 										'_ajax_nonce': '<?php echo wp_create_nonce( 'super_duper_output_shortcode' );?>'
 									};
 


### PR DESCRIPTION
…ng - FIXED

* WP 5.7 Gutenberg widgets screen legacy widgets have no `show advanced` button - FIXED